### PR TITLE
[#99782882] Allow the retention policy of influxdb to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following ansible variables are used by this role - the default values are s
 * influxdb_user: someuser # A non-privliged database user account for `influxdb_database`.
 * influxdb_password: somepassword # the password for `influxdb_user` account.
 * influxdb_http_auth_enabled: false # to disable or `true` to enable http authentication.
+* influxdb_retention_period: INF # for infinite retention, durations such as 1h, 90m, 12h, 7d, and 4w, are all supported
 ```
 
 You will want to override these role variables within your playbooks.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ influxdb_admin_password: root
 influxdb_database: testdb
 influxdb_user: someuser
 influxdb_password: somepassword
+influxdb_retention_period: INF

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,3 +31,9 @@
 - name: grant privileges to user for influxdb database
   shell: "curl -G http://localhost:8086/query --data-urlencode \"u={{ influxdb_admin_user }}\" --data-urlencode \"p={{ influxdb_admin_password }}\" --data-urlencode \"q=GRANT ALL ON {{ influxdb_database }} TO {{ influxdb_user }}\""
 
+- name: set retention policy for influxdb_database
+  shell: >
+    curl -G http://localhost:8086/query
+    --data-urlencode "u={{ influxdb_admin_user }}"
+    --data-urlencode "p={{ influxdb_admin_password }}"
+    --data-urlencode "q=ALTER RETENTION POLICY default ON {{ influxdb_database }} DURATION {{ influxdb_retention_period }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,16 +20,32 @@
   wait_for: port=8086 timeout=60
 
 - name: create admin user for all influxdb databases
-  shell: "curl -G http://localhost:8086/query --data-urlencode \"u={{ influxdb_admin_user }}\" --data-urlencode \"p={{ influxdb_admin_password }}\" --data-urlencode \"q=CREATE USER {{ influxdb_admin_user }} WITH PASSWORD '{{ influxdb_admin_password }}' WITH ALL PRIVILEGES\""
+  shell: >
+     curl -G http://localhost:8086/query
+     --data-urlencode "u={{ influxdb_admin_user }}"
+     --data-urlencode "p={{ influxdb_admin_password }}"
+     --data-urlencode "q=CREATE USER {{ influxdb_admin_user }} WITH PASSWORD '{{ influxdb_admin_password }}' WITH ALL PRIVILEGES"
 
 - name: create influxdb database
-  shell: "curl -G http://localhost:8086/query --data-urlencode \"u={{ influxdb_admin_user }}\" --data-urlencode \"p={{ influxdb_admin_password }}\" --data-urlencode \"q=CREATE DATABASE {{ influxdb_database }}\""
+  shell: >
+     curl -G http://localhost:8086/query
+     --data-urlencode "u={{ influxdb_admin_user }}"
+     --data-urlencode "p={{ influxdb_admin_password }}"
+     --data-urlencode "q=CREATE DATABASE {{ influxdb_database }}"
 
 - name: create user for influxdb database
-  shell: "curl -G http://localhost:8086/query --data-urlencode \"u={{ influxdb_admin_user }}\" --data-urlencode \"p={{ influxdb_admin_password }}\" --data-urlencode \"q=CREATE USER {{ influxdb_user }} WITH PASSWORD '{{ influxdb_password }}'\""
+  shell: >
+     curl -G http://localhost:8086/query
+     --data-urlencode "u={{ influxdb_admin_user }}"
+     --data-urlencode "p={{ influxdb_admin_password }}"
+     --data-urlencode "q=CREATE USER {{ influxdb_user }} WITH PASSWORD '{{ influxdb_password }}'"
 
 - name: grant privileges to user for influxdb database
-  shell: "curl -G http://localhost:8086/query --data-urlencode \"u={{ influxdb_admin_user }}\" --data-urlencode \"p={{ influxdb_admin_password }}\" --data-urlencode \"q=GRANT ALL ON {{ influxdb_database }} TO {{ influxdb_user }}\""
+  shell: >
+     curl -G http://localhost:8086/query
+     --data-urlencode "u={{ influxdb_admin_user }}"
+     --data-urlencode "p={{ influxdb_admin_password }}"
+     --data-urlencode "q=GRANT ALL ON {{ influxdb_database }} TO {{ influxdb_user }}"
 
 - name: set retention policy for influxdb_database
   shell: >


### PR DESCRIPTION
[Set the influxDB retention policy](https://www.pivotaltracker.com/story/show/99782882)

**What**

Currently InfluxDB has an infiniten retention policy by default and simply fills the disk. This breaks ansible deploys, as ansible cannot even create temporary directories for its run.

**How this PR should be reviewed**

This PR has been written with the following narrative:
- I would like to create a new variable that I can use to define the desired retention policy period
- I want to add a task that will alter the default retention policy to fit my desired retention policy period
- I want to change the existing curl related tasks so they match the `default retention policy` task because it is easier to read

**How to test this PR**

A vagrant box has been provided for verification, you can validate this PR by doing:
- `vagrant up`
- `vagrant ssh`
- `/opt/influxdb/versions/0.9.0/influx -database 'testdb'`
- `SHOW RETENTION POLICIES ON testdb`
- `EXIT`
- Log out of vagrant
- Alter site.yml to the following:

```
...
vars:
  - influxdb_retention_period: 1h
...
```
- `vagrant provision`
- `vagrant ssh`
- `/opt/influxdb/versions/0.9.0/influx -database 'testdb'`
- `SHOW RETENTION POLICIES ON testdb`
- `EXIT`

**Who should review this PR**
- An Awkward Aardvark, if a quirky ann eater can not be readily found then any member of the core team will do

**Who can merge this PR**
- Anyone on the core team except @mtekel who I paired with :p
