### PR TITLE
[#106191568] update config to support latest version of Influxdb, 0.9.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ansible role for deploying the [Influxfb](https://github.com/influxdb/influxdb) time series database
 
+Tested with influxdb version 0.9.4.2
+
 ### Requirements
 
 The following ansible variables are used by this role - the default values are shown alongside.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,4 @@
 ---
 # handlers file for ansible-playbook-influxdb
+- name: restart influxdb
+  service: name=influxdb enabled=yes state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,8 @@
   command: dpkg --skip-same-version -i --force-all /tmp/influxdb_{{ influxdb_version }}_amd64.deb
   register: dpkg_result
   changed_when: "dpkg_result.stdout.startswith('Selecting')"
+  notify:
+  - restart influxdb
 
 - name: configure influxdb service
   template: src=influxdb.conf.j2 dest=/etc/opt/influxdb/influxdb.conf owner=root group=root mode=0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   get_url: url=http://s3.amazonaws.com/influxdb/influxdb_{{ influxdb_version }}_amd64.deb dest=/tmp/influxdb_{{ influxdb_version }}_amd64.deb mode=0440
 
 - name: install influxdb package
-  command: dpkg --skip-same-version -i /tmp/influxdb_{{ influxdb_version }}_amd64.deb
+  command: dpkg --skip-same-version -i --force-all /tmp/influxdb_{{ influxdb_version }}_amd64.deb
   register: dpkg_result
   changed_when: "dpkg_result.stdout.startswith('Selecting')"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: install influxdb package
   command: dpkg --skip-same-version -i --force-all /tmp/influxdb_{{ influxdb_version }}_amd64.deb
   register: dpkg_result
-  changed_when: "dpkg_result.stdout.startswith('Selecting')"
+  changed_when: not dpkg_result.stderr.endswith('skipping')
   notify:
   - restart influxdb
 

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -28,11 +28,47 @@ reporting-disabled = false
 ###
 ### [data]
 ###
-### Controls where the actual shard data for InfluxDB lives.
+### Controls where the actual shard data for InfluxDB lives and how it is
+### flushed from the WAL. "dir" may need to be changed to a suitable place
+### for your system, but the WAL settings are an advanced configuration. The
+### defaults should work for most systems.
 ###
 
 [data]
   dir = "/var/opt/influxdb/data"
+
+  # Controls the engine type for new shards.
+  # engine ="bz1"
+
+  # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
+  # apply to any new shards created after upgrading to a version > 0.9.3.
+  max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
+  wal-flush-interval = "10m" # Maximum time data can sit in WAL before a flush.
+  wal-partition-flush-delay = "2s" # The delay time between each WAL partition being flushed.
+
+  # These are the WAL settings for the storage engine >= 0.9.3
+  wal-dir = "/var/opt/influxdb/wal"
+  wal-enable-logging = true
+
+  # When a series in the WAL in-memory cache reaches this size in bytes it is marked as ready to
+  # flush to the index
+  # wal-ready-series-size = 25600
+
+  # Flush and compact a partition once this ratio of series are over the ready size
+  # wal-compaction-threshold = 0.6
+
+  # Force a flush and compaction if any series in a partition gets above this size in bytes
+  # wal-max-series-size = 2097152
+
+  # Force a flush of all series and full compaction if there have been no writes in this
+  # amount of time. This is useful for ensuring that shards that are cold for writes don't
+  # keep a bunch of data cached in memory and in the WAL.
+  # wal-flush-cold-interval = "10m"
+
+  # Force a partition to flush its largest series if it reaches this approximate size in
+  # bytes. Remember there are 5 partitions so you'll need at least 5x this amount of memory.
+  # The more memory you have, the bigger this can be.
+  # wal-partition-size-threshold = 20971520
 
 ###
 ### [cluster]
@@ -42,7 +78,8 @@ reporting-disabled = false
 ###
 
 [cluster]
-  shard-writer-timeout = "5s"
+  shard-writer-timeout = "5s" # The time within which a shard must respond to write.
+  write-timeout = "5s" # The time within which a write operation must complete on the cluster.
 
 ###
 ### [retention]
@@ -52,17 +89,33 @@ reporting-disabled = false
 
 [retention]
   enabled = true
-  check-interval = "10m"
+  check-interval = "30m"
+
+###
+### Controls the system self-monitoring, statistics and diagnostics.
+###
+### The retention policy for this data is the default retention policy within
+### the internal database. The internal database is created automatically if
+### if it does not already exist, as is the default retention policy. If you
+### want to use a non-default retention policy, it must be explicitly created.
+
+[monitor]
+  store-enabled = true # Whether to record statistics internally.
+  store-database = "_internal" # The destination database for recorded statistics
+  store-interval = "10s" # The interval at which to record statistics
 
 ###
 ### [admin]
 ###
-### Controls the availability of the built-in, web-based admin interface.
+### Controls the availability of the built-in, web-based admin interface. If HTTPS is
+### enabled for the admin interface, HTTPS must also be enabled on the [http] service.
 ###
 
 [admin]
   enabled = true
   bind-address = ":8083"
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
 
 ###
 ### [http]
@@ -78,6 +131,8 @@ reporting-disabled = false
   log-enabled = true
   write-tracing = false
   pprof-enabled = false
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
 
 ###
 ### [[graphite]]
@@ -91,7 +146,34 @@ reporting-disabled = false
   # protocol = "tcp"
   # consistency-level = "one"
   # name-separator = "."
-  # name-position = "last"
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+
+  ## "name-schema" configures tag names for parsing the metric name from graphite protocol;
+  ## separated by `name-separator`.
+  ## The "measurement" tag is special and the corresponding field will become
+  ## the name of the metric.
+  ## e.g. "type.host.measurement.device" will parse "server.localhost.cpu.cpu0" as
+  ## {
+  ##     measurement: "cpu",
+  ##     tags: {
+  ##         "type": "server",
+  ##         "host": "localhost,
+  ##         "device": "cpu0"
+  ##     }
+  ## }
+  # name-schema = "type.host.measurement.device"
+
+  ## If set to true, when the input metric name has more fields than `name-schema` specified,
+  ## the extra fields will be ignored.
+  ## Otherwise an error will be logged and the metric rejected.
+  # ignore-unnamed = true
 
 ###
 ### [collectd]
@@ -105,6 +187,14 @@ reporting-disabled = false
   # database = ""
   # typesdb = ""
 
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+
 ###
 ### [opentsdb]
 ###
@@ -117,26 +207,32 @@ reporting-disabled = false
   # database = ""
   # retention-policy = ""
 
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Only points
+  # metrics received over the telnet protocol undergo batching.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+
 ###
-### [udp]
+### [[udp]]
 ###
-### Controls the listener for InfluxDB line protocol data via UDP.
+### Controls the listeners for InfluxDB line protocol data via UDP.
 ###
 
-[udp]
+[[udp]]
   enabled = false
   # bind-address = ""
   # database = ""
-  # batch-size = 0
-  # batch-timeout = "0"
 
-###
-### [monitoring]
-###
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
 
-[monitoring]
-  enabled = true
-  write-interval = "24h"
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
 
 ###
 ### [continuous_queries]
@@ -145,6 +241,7 @@ reporting-disabled = false
 ###
 
 [continuous_queries]
+  log-enabled = true
   enabled = true
   recompute-previous-n = 2
   recompute-no-older-than = "10m"


### PR DESCRIPTION
[#106191568 Monitoring dashboard for the trial Tsuru platform](https://www.pivotaltracker.com/story/show/106191568)
# What

For the monitoring dashboard for tsuru, we decided to upgrade influxdb to 0.9.4.2.

We need new configuration for that.
# How to test this?
- Update the version in `site.yml` to add the variable `influxdb_version: 0.9.4.2` and do: `vagrant up`:

```

---
- hosts: all
  sudo: yes
  vars:
     influxdb_version: 0.9.4.2
  roles:
    - .
```
- Test if it restarts when using different version (ex: 9.3)
# After review

Please update the release as a final release.
# Who can review this?

Anyone but @keymon @saliceti or @combor 
